### PR TITLE
FIX - 핑크시슬리에서 포토리뷰 클릭시 iframe으로 뜨도록 수정

### DIFF
--- a/views/mobile/products/reviews/summary/_thumbnail.html.erb
+++ b/views/mobile/products/reviews/summary/_thumbnail.html.erb
@@ -15,7 +15,13 @@
     <% review_images.select {|r| r.class == ReviewImageUploader}[0..15].each do |image| %>
       <li class="photo_thumbnail photo photo-review-thumbnail">
         <% review = image.review %>
-        <%= link_to photo_review_popup_mobile_review_path(review, photo_index: image.index), target: '_blank' do %>
+        <%= content_tag(
+          :a,
+          class: 'photo-review-popup',
+          data: {
+            photo_review_popup_url: photo_review_popup_mobile_review_path(review, photo_index: image.index)
+          }
+        ) do %>
           <%= image_tag image.url(:thumbnail), class: 'review-image smooth', alt: review.title, width: 56, height: 56 %>
         <% end %>
       </li>

--- a/views/mobile/reviews/photo_review_popup.html.erb
+++ b/views/mobile/reviews/photo_review_popup.html.erb
@@ -46,8 +46,8 @@
     </div>
   </div>
   <div class="close-button hidden" id="photo-close">
-    <div class="button-icon"><i class="fa fa-arrow-left"></i></div>
-    <div class="button-name">뒤로</div>
+    <div class="button-icon"><i class="fa fa-times"></i></div>
+    <div class="button-name"><%= t('reviews.label_close') %></div>
   </div>
   <div class="index-indicator without-summary">
     <% (1..@photos_count).each do |i| %>


### PR DESCRIPTION
### 이유
- 모든 포토리뷰 팝업은 새창이 아닌 iframe으로 뜨도록 변경했는데 핑크시슬리 풀커스텀에 반영이 안되어 있었음
- 그래서 뒤로가기 버튼 동작 안함

https://app.asana.com/0/search/187939442385054/195111918174953