### PR TITLE
FIX - 포토리뷰 팝업 안뜨는 문제

### DIFF
--- a/assets/javascripts/pc/app/reviews.js.coffee
+++ b/assets/javascripts/pc/app/reviews.js.coffee
@@ -316,8 +316,8 @@ $(document).on "history:updated", (e, elements) ->
       escapeMarkup: (m) -> m
       })
 
-$(document).on "click", ".photo-review-popup", ->
-  app.window.photo_review_popup $(this).data("photo-review-popup-url")
+$(document).on "click", ".link-fullscreen-popup", ->
+  app.window.photo_review_popup $(this).data("url")
   app.reviews.review_popup_loader $(this)
 
 $(document).on "click", ".delete-review, .edit-review, .new_review, .review-edit-close", ->

--- a/assets/javascripts/pc/app/reviews.js.coffee
+++ b/assets/javascripts/pc/app/reviews.js.coffee
@@ -316,10 +316,6 @@ $(document).on "history:updated", (e, elements) ->
       escapeMarkup: (m) -> m
       })
 
-$(document).on "click", ".link-fullscreen-popup", ->
-  app.window.photo_review_popup $(this).data("url")
-  app.reviews.review_popup_loader $(this)
-
 $(document).on "click", ".delete-review, .edit-review, .new_review, .review-edit-close", ->
   $old_form = $("#review-edit-form");
   if $old_form.length > 0

--- a/views/mobile/products/reviews/_review.html.erb
+++ b/views/mobile/products/reviews/_review.html.erb
@@ -96,9 +96,9 @@ display_user_grade_icon = user_grade_icon_url.present? && @brand.brand_user_grad
           <div class="review_image">
             <%= content_tag(
               :a,
-              class: 'photo-review-popup',
+              class: 'link-fullscreen-popup',
               data: {
-                photo_review_popup_url: photo_review_popup_mobile_review_path(review, photo_index: 1)
+                url: photo_review_popup_mobile_review_path(review, photo_index: 1)
               }
             ) do %>
               <%= image_tag review.image(1).url(:portrait), class: 'review-image smooth', alt: review.title, width: review.image(1).width(:portrait), height: review.image(1).height(:portrait) %>

--- a/views/mobile/products/reviews/summary/_thumbnail.html.erb
+++ b/views/mobile/products/reviews/summary/_thumbnail.html.erb
@@ -17,9 +17,9 @@
         <% review = image.review %>
         <%= content_tag(
           :a,
-          class: 'photo-review-popup',
+          class: 'link-fullscreen-popup',
           data: {
-            photo_review_popup_url: photo_review_popup_mobile_review_path(review, photo_index: image.index)
+            url: photo_review_popup_mobile_review_path(review, photo_index: image.index)
           }
         ) do %>
           <%= image_tag image.url(:thumbnail), class: 'review-image smooth', alt: review.title, width: 56, height: 56 %>


### PR DESCRIPTION
### 수정 내용
- .photo-review-popup을 .link-fullscreen-popup 으로 변경
- .photo-review-popup 처리로직을 reviews.js.coffee 에서 제거 (fullscreen_popup.js.coffee 에서 하도록 변경됐음)