### PR TITLE
FIX - 모바일 포토 리뷰 팝업에서 상품 리뷰 링크 클릭 시 뜨는 창의 닫기 버튼 클릭 시 안 닫히고 다른 페이지로 이동

### DIFF
--- a/views/mobile/reviews/photo_review_popup.html.erb
+++ b/views/mobile/reviews/photo_review_popup.html.erb
@@ -60,7 +60,7 @@
       <%= @review.message %>
     </div>
     <div class="review-top">
-      <%= link_to mobile_review_url(@review, close_url: close_url), class: 'link-to-review', target: '_blank' do %>
+      <%= link_to mobile_review_url(@review), class: 'link-to-review', target: '_blank' do %>
         <div class="product-thumbnail">
           <%= image_tag(product.image.url(:extra_small), width: 28, height: 28) if product %>
         </div>


### PR DESCRIPTION
### 원인
- target을 ‘_blank’로 설정해서 새창으로 여는 link에 close_url을 넣었음
- close_url을 넣으면 닫기 버튼이 창 닫힘으로 동작하는것이 아니고 해당 url로 이동하는 것으로 동작하게 됨
- https://github.com/crema/crema/commit/8ea95b83c6b2292b3f9e52dc40f0be31da2da1b5 에서 `target: ‘_blank’` 를 삽입하면서 close_url은 그냥 두면서 발생한 문제

### 수정 내용
- 모바일 포토 리뷰 팝업의 상품 리뷰 링크에서 close_url을 제거

https://app.asana.com/0/113613906143880/245325520877180