### PR TITLE
FIX - 모바일 리뷰 작성할 때 오류가 발생하는 문제

### DIFF
--- a/views/mobile/reviews/_form.html.erb
+++ b/views/mobile/reviews/_form.html.erb
@@ -61,7 +61,7 @@ end
         data: {
           review_message_default: @brand.review_message_default,
           already_posted: @review.new_record? && @review.product.already_posted?(current_user) ? t('reviews.form.already_posted') : nil,
-          already_posted_return_url: app ? pending_mobile_reviews_url : nil,
+          already_posted_return_url: widget_env_stand_alone? ? pending_mobile_reviews_url : nil,
           alert_requirement: @brand.review_alert_mileage_requirement_before_submit,
           disable_save_requirement: @brand.disable_review_with_insufficient_review_length
         } do |f| %>


### PR DESCRIPTION
## 원인
- [crema repository](https://github.com/crema/crema/commit/7d595341274a3691c9f5f315c2f085c7b080b869) 에서 수정되었지만, 커스텀에는 반영이 안되었음.

## 수정 사항
- sms 등 외부 링크에서 시작된 위젯은 `WidgetExecutionEnvironment::STAND_ALONE` 으로 처리하는 것으로 변경되었으므로 `app -> widget_env_stand_alone?` 으로 수정

https://app.asana.com/0/search/292436141954043/305420005361626