### PR TITLE
FIX - 모바일 상품 위젯 내 ‘포토리뷰 모아보기’ 글씨 크기가 라이브와 다른 문제

### DIFF
--- a/assets/stylesheets/mobile/app/reviews/product.css.scss
+++ b/assets/stylesheets/mobile/app/reviews/product.css.scss
@@ -172,6 +172,7 @@
   text-align: center;
   height: 56px;
   padding: 9px 0px;
+  font-size: 12px;
 
   .show-all-photo-reviews, .count-text {
     padding: 2px 0;


### PR DESCRIPTION
## 원인
- https://github.com/crema/crema/commit/3b021d89ba5e835398164a57bdd33cc64301aa0a 에서 `#content { font-size: 12px; }` 가 빠지면서 생긴 현상

## 수정 사항
- `#review-photo-summary`에 `font-size: 12px;` 추가

https://app.asana.com/0/search/297696223368726/307672421827195