### PR TITLE
FIX - 모바일 상세위젯 댓글 작성버튼이 깨져보이는 문제

### DIFF
--- a/assets/stylesheets/mobile/app/products/reviews.css.scss
+++ b/assets/stylesheets/mobile/app/products/reviews.css.scss
@@ -64,6 +64,13 @@ body.products.reviews {
       padding: 4px 50px 4px 12px;
     }
 
+    .new-comments__input {
+      width: 100%;
+      height: 24px;
+      font-size: 13px;
+      line-height: 24px;
+    }
+
     .new-comments__button {
       border-left: 2px solid #e4e4e4;
       height: 32px;

--- a/views/mobile/products/reviews/_review.html.erb
+++ b/views/mobile/products/reviews/_review.html.erb
@@ -101,7 +101,11 @@ display_user_grade_icon = user_grade_icon_url.present? && @brand.brand_user_grad
                 url: photo_review_popup_mobile_review_path(review, photo_index: 1)
               }
             ) do %>
-              <%= image_tag review.image(1).url(:portrait), class: 'review-image smooth', alt: review.title, width: review.image(1).width(:portrait), height: review.image(1).height(:portrait) %>
+              <%
+                review_image_1 = review.image(1)
+                w, h = review_image_1.dimension(:portrait)
+              %>
+              <%= image_tag review_image_1.url(:portrait), class: 'review-image smooth', alt: review.title, width: w, height: h %>
             <% end %>
             <% if review.images_count > 1 %>
               <div class="review_image__see_more">+ 사진 더보기</div>

--- a/views/mobile/reviews/show.html.erb
+++ b/views/mobile/reviews/show.html.erb
@@ -113,7 +113,7 @@
             <div class="panel-body">
               <div class="new-comments">
                 <%= form_for Comment.new, url: mobile_comments_path, validate: true, remote: true, data: {login_required: true} do |f| %>
-                  <%= f.text_field :message, placeholder: '댓글을 작성해 주세요 :)', class: 'input-block', data: {login_required: true} %>
+                  <%= f.text_field :message, placeholder: '댓글을 작성해 주세요 :)', class: 'new-comments__input input-block', data: {login_required: true} %>
                   <%= f.hidden_field :review_id, value: @review.id %>
                   <%= content_tag :button, '등록', class: 'btn btn-lg' %>
                   <input type="hidden" name="tracking_id">

--- a/views/pc/products/reviews/option_types/_option_type.html.erb
+++ b/views/pc/products/reviews/option_types/_option_type.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag_for :li, option_type do %>
   <%= content_tag :a, class: 'link-review-option-type' do %>
     <span class="type-name"><%= option_type.name %></span>
-    <span style="position: absolute; top: -12px; right: 6px;"><img src="http://pinksisly.cdn.smart-img.com/event/sangse-sizedown.jpg"></span>
+    <span style="position: absolute; top: -12px; right: -11px;"><img src="http://pinksisly.cdn.smart-img.com/event/sangse-sizedown.jpg"></span>
   <% end %>
   <%= content_tag :div, class: "dropdown-menu #{'nonlast-option' if review_option_types_count != option_type_counter + 1} dialog-iframe-height" do %>
     <%= render "products/reviews/option_types/search_#{ReviewOptionFieldType.key_string(option_type.field_type)}", option_type: option_type %>


### PR DESCRIPTION
## 원인
- 현재 라이브에서 적용되고 있는 css 속성과 스태이징 서버에서 적용되고 있는 것을 비교해보니까 스크린샷에서 나와있는 속성들이 스태이징에서는 적용이 안되고 있었음

#### ***밑에 보이는 스크린샷은 라이브에서 적용되고 있는 속성***
![image](https://cloud.githubusercontent.com/assets/6479241/24535414/e1f432f8-160e-11e7-804c-5ca434f1d38b.png)



## 수정 사항
- 라이브와 동일한 속성들을 추가하는데 다른 점이 있다면 BEM 방식으로 class를 추가

https://app.asana.com/0/222280601547638/307674733003357