### PR TITLE
FIX - 포토리뷰 팝업에서 닫기 버튼 클릭시 아무동작도 하지 않는 문제

### DIFF
--- a/views/mobile/reviews/photo_review_popup.html.erb
+++ b/views/mobile/reviews/photo_review_popup.html.erb
@@ -64,7 +64,7 @@
       <%= @review.message %>
     </div>
     <div class="review-top">
-      <%= link_to mobile_review_url(@review), class: 'link-to-review', target: '_blank' do %>
+      <%= content_tag :a, class: 'link-to-review link-iframe', data: {url: mobile_review_url(@review)} do %>
         <div class="product-thumbnail">
           <%= image_tag(product.image.url(:extra_small), width: 28, height: 28) if product %>
         </div>


### PR DESCRIPTION
## 원인
- 커스텀 업체라서 https://github.com/crema/crema/commit/bd1911794a7feef478d234b1c6eb340e4e4d795a 에서 수정된 내용이 반영되지 않음

## 수정 내용
- 앱에서의 문제 때문에 앞으로는 새창으로 열리는 대신 현재 창이 redirect 되도록 수정

https://app.asana.com/0/222013116405879/307672421827199