### PR TITLE
FIX - 모바일 상세위젯 댓글 등록 버튼의 하단 테두리가 없는 문제

### DIFF
--- a/views/mobile/products/reviews/_review.html.erb
+++ b/views/mobile/products/reviews/_review.html.erb
@@ -126,7 +126,7 @@ display_user_grade_icon = user_grade_icon_url.present? && @brand.brand_user_grad
           <div class="action__new_comment">
             <div class="new-comments">
               <%= form_for Comment.new, url: mobile_comments_path, validate: true, remote: true, data: {login_required: true} do |f| %>
-                <%= f.text_field :message, placeholder: t('reviews.comments.please_write_comments'), class: 'input-block', data: {login_required: true} %>
+                <%= f.text_field :message, placeholder: t('reviews.comments.please_write_comments'), class: 'new-comments__input input-block', data: {login_required: true} %>
                 <%= f.hidden_field :review_id, value: review.id %>
                 <%= content_tag :button, t('post'), class: 'btn btn-lg new-comments__button' %>
                 <input type="hidden" name="tracking_id">


### PR DESCRIPTION
## 원인
- #15 PR 과 동일한 문제

## 수정 사항
- #15와 마찬가지로 `new-comments__input` 클래스 추가

https://app.asana.com/0/222280601547638/307674733003357